### PR TITLE
[ci] measure coverage (test_cov & codecov)

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -29,8 +29,14 @@ jobs:
         run: dart analyze --fatal-infos --fatal-warnings .
 
       - name: Run regression tests
-        run: dart test
+        run: dart run test_cov
         env:
           XDG_DATA_DIRS: ${{ github.workspace }}/test
           XDG_CONFIG_HOME: ${{ github.workspace }}/test
           DCONF_PROFILE: ${{ github.workspace }}/test/dconf/test-profile
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+        with:
+          file: coverage/lcov.info
+          token: ${{secrets.CODECOV_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .dart_tool/
 .packages
 pubspec.lock
+test/.test_cov.dart
+coverage/

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,1 @@
+comment: false

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,3 +16,4 @@ dependencies:
 dev_dependencies:
   pedantic: ^1.9.0
   test: ^1.16.8
+  test_cov: ^1.0.1


### PR DESCRIPTION
### Measure coverage
```bash
jpnurmi@jpnurmi-XPS-13-9310:~/Projects/dart/gsettings.dart (coverage)$ dart run test_cov
Found 1 test files.
Generated test-all script in test/.test_cov.dart.
Observatory listening on http://127.0.0.1:8181/CyqOSY84H7E=/
The Dart DevTools debugger and profiler is available at: http://127.0.0.1:8181/CyqOSY84H7E=/devtools/#/?uri=ws%3A%2F%2F127.0.0.1%3A8181%2FCyqOSY84H7E%3D%2Fws
00:00 +0: GVariant text encode

00:00 +1: GVariant text decode

00:00 +2: GVariant binary encode

00:00 +3: GVariant binary decode

00:00 +4: GSettings list schemas

00:00 +5: GSettings unknown schema

00:00 +6: GSettings list keys

00:00 +7: GSettings get - preset

00:00 +8: GSettings get - unset

00:00 +9: GSettings unknown key

00:00 +10: All tests passed!

Coverage report saved to "coverage/lcov.info".
```

### Generate coverage report
```bash
jpnurmi@jpnurmi-XPS-13-9310:~/Projects/dart/gsettings.dart (coverage)$ genhtml coverage/lcov.info -o coverage
Reading data file coverage/lcov.info
Resolved relative source file path "lib/src/gvariant_binary_codec.dart" with CWD to "/home/jpnurmi/Projects/dart/gsettings.dart/lib/src/gvariant_binary_codec.dart".
Found 6 entries.
Found common filename prefix "/home/jpnurmi/Projects/dart/gsettings.dart/lib"
Writing .css and .png files.
Generating output.
Processing file src/dconf_client.dart
Processing file src/getuid_linux.dart
Processing file src/gvariant_database.dart
Processing file src/gvariant_text_codec.dart
Processing file src/gvariant_binary_codec.dart
Processing file src/gsettings.dart
Writing directory view page.
Overall coverage rate:
  lines......: 82.1% (774 of 943 lines)
  functions..: no data found
```

=> `coverage/index.html`